### PR TITLE
Fixing the problem, adding some extras

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,22 @@
+# Folder view configuration files
+.DS_Store
+Desktop.ini
+
+# Thumbnail cache files
+._*
+Thumbs.db
+
+# Files that might appear on external disks
+.Spotlight-V100
+.Trashes
+
+# Compiled Python files
+*.pyc
+
+# Compiled C++ files
+*.out
+
+# Application specific files
+venv
+node_modules
+.sass-cache

--- a/esphome/base/advanced.yaml
+++ b/esphome/base/advanced.yaml
@@ -7,7 +7,7 @@ sensor:
     platform: modbus_controller
     modbus_controller_id: ${modbus_id}
     icon: mdi:information-box
-    skip_updates: ${skip_updates_advanced}
+    skip_updates: ${skip_updates.advanced}
   - name: Sub-ID van de fabrikant
     address: 11
     value_type: U_WORD
@@ -16,7 +16,7 @@ sensor:
     platform: modbus_controller
     modbus_controller_id: ${modbus_id}
     icon: mdi:information-box
-    skip_updates: ${skip_updates_advanced}
+    skip_updates: ${skip_updates.advanced}
   - name: ProductNoneID
     address: 12
     value_type: U_WORD
@@ -25,7 +25,7 @@ sensor:
     platform: modbus_controller
     modbus_controller_id: ${modbus_id}
     icon: mdi:information-box
-    skip_updates: ${skip_updates_advanced}
+    skip_updates: ${skip_updates.advanced}
   - name: Softwareversie
     address: 13
     value_type: U_WORD
@@ -34,7 +34,7 @@ sensor:
     platform: modbus_controller
     modbus_controller_id: ${modbus_id}
     icon: mdi:information-box
-    skip_updates: ${skip_updates_advanced}
+    skip_updates: ${skip_updates.advanced}
   - name: Softwarerevisie
     address: 14
     value_type: U_WORD
@@ -43,7 +43,7 @@ sensor:
     platform: modbus_controller
     modbus_controller_id: ${modbus_id}
     icon: mdi:information-box
-    skip_updates: ${skip_updates_advanced}
+    skip_updates: ${skip_updates.advanced}
   - name: Lijstversie
     address: 15
     value_type: U_WORD
@@ -52,7 +52,7 @@ sensor:
     platform: modbus_controller
     modbus_controller_id: ${modbus_id}
     icon: mdi:information-box
-    skip_updates: ${skip_updates_advanced}
+    skip_updates: ${skip_updates.advanced}
   - name: OEM-code
     address: 16
     value_type: U_WORD
@@ -61,7 +61,7 @@ sensor:
     platform: modbus_controller
     modbus_controller_id: ${modbus_id}
     icon: mdi:information-box
-    skip_updates: ${skip_updates_advanced}
+    skip_updates: ${skip_updates.advanced}
   - name: Serienummer deel 1 (uint 64) (MSB)
     address: 100
     value_type: U_WORD
@@ -70,7 +70,7 @@ sensor:
     platform: modbus_controller
     modbus_controller_id: ${modbus_id}
     icon: mdi:information-box
-    skip_updates: ${skip_updates_advanced}
+    skip_updates: ${skip_updates.advanced}
   - name: Serienummer deel 2 (uint 64)
     address: 101
     value_type: U_WORD
@@ -79,7 +79,7 @@ sensor:
     platform: modbus_controller
     modbus_controller_id: ${modbus_id}
     icon: mdi:information-box
-    skip_updates: ${skip_updates_advanced}
+    skip_updates: ${skip_updates.advanced}
   - name: Serienummer deel 3 (uint 64)
     address: 102
     value_type: U_WORD
@@ -88,7 +88,7 @@ sensor:
     platform: modbus_controller
     modbus_controller_id: ${modbus_id}
     icon: mdi:information-box
-    skip_updates: ${skip_updates_advanced}
+    skip_updates: ${skip_updates.advanced}
   - name: Serienummer deel 4 (uint 64) (LSB)
     address: 103
     value_type: U_WORD
@@ -97,7 +97,7 @@ sensor:
     platform: modbus_controller
     modbus_controller_id: ${modbus_id}
     icon: mdi:information-box
-    skip_updates: ${skip_updates_advanced}
+    skip_updates: ${skip_updates.advanced}
 
 number:
   # Changing these will also make you change your yaml files: 
@@ -107,7 +107,7 @@ number:
     register_type: holding
     platform: modbus_controller
     modbus_controller_id: ${modbus_id}
-    skip_updates: ${skip_updates_advanced}
+    skip_updates: ${skip_updates.advanced}
     icon: mdi:cog
     min_value: 1
     max_value: 247
@@ -118,7 +118,7 @@ number:
     register_type: holding
     platform: modbus_controller
     modbus_controller_id: ${modbus_id}
-    skip_updates: ${skip_updates_advanced}
+    skip_updates: ${skip_updates.advanced}
     icon: mdi:cog
     min_value: 0
     max_value: 4
@@ -129,7 +129,7 @@ number:
     register_type: holding
     platform: modbus_controller
     modbus_controller_id: ${modbus_id}
-    skip_updates: ${skip_updates_advanced}
+    skip_updates: ${skip_updates.advanced}
     icon: mdi:cog
     min_value: 0
     max_value: 2

--- a/esphome/base/base.yaml
+++ b/esphome/base/base.yaml
@@ -2,32 +2,37 @@
 # Modbus Settings
 ###
 modbus:
-  id: modbuswtw
-  uart_id: uart_modbus
-  #send_wait_time: 2000ms
+  id:                     modbuswtw
+  uart_id:                uart_modbus
 
 modbus_controller:
-  - id: wtw
-    address:          0x48 # Resolves to 72
-    modbus_id:        modbuswtw
-    setup_priority:   -10
-    update_interval:  15s
-    command_throttle: 200ms
-    offline_skip_updates: 100
+  - id:                   wtw
+    address:              0x48 # Resolves to 72
+    modbus_id:            modbuswtw
+    setup_priority:       -10
+    #update_interval:      15s
+    command_throttle:     50ms
+    #offline_skip_updates: 100
 
+###
+# Substitutions
+###
 substitutions:
-  skip_updates: "5"
-  skip_updates_errors: "10"
-  skip_updates_advanced: "100"
-  modbus_id: wtw
-  max_cap: "399"
-  flap_max: "550"
-  alert_icon: mdi:alert-circle
-  max_error_number: "5"
-  fan_speed_1: "100"
-  fan_speed_2: "150"
-  fan_speed_3: "200"
-  fan_speed_4: "250"
-  fan_speed_5: "300"
-  fan_speed_6: "350"
-  fan_speed_7: "399"
+  modbus_id:              wtw
+  alert_icon:             mdi:alert-circle
+  skip_updates:
+    base:                 5
+    errors:               10
+    advanced:             100
+  max:
+    error_number:         5
+    flap:                 550
+    cap:                  399
+  fan:
+    speed_1:              100
+    speed_2:              150
+    speed_3:              200
+    speed_4:              250
+    speed_5:              300
+    speed_6:              350
+    speed_7:              399

--- a/esphome/base/bypass.yaml
+++ b/esphome/base/bypass.yaml
@@ -1,37 +1,34 @@
+###
+# Summer bypass
+###
+# States:
+## 0   = open, 550 = Closed
+# What is it:
+## Inside air is directed to the ourside without passing the heat exchanger
+## Thus cold outside air does not heat up from the hot inside air
+
 number:
-  ###
-  # Bypass
-  ###
-  # 0 = down 
-  # 550 = open
-  # Inside air is directed to the ourside without passing the heat exchanger
-  # Thus cold outside air does not heat up from the hot inside air
-  - name: ${b_2032}
-    address: 2032
-    #value_type: U_WORD
-    min_value: 0
-    max_value: ${flap_max}
-    step: ${flap_max}
-    #initial_value: 0
-    register_type: holding
-    platform: modbus_controller
-    use_write_multiple: true
-    modbus_controller_id: ${modbus_id}
-    icon: mdi:valve
+  # seems not to be updated.
+  # - name: ${b_2032}
+  #   address: 2032
+  #   id: bypass_valve_value
+  #   min_value: 0
+  #   max_value: ${max.flap}
+  #   step: ${max.flap}
+  #   platform: modbus_controller
+  #   use_write_multiple: true
+  #   modbus_controller_id: ${modbus_id}
+  #   icon: mdi:valve
   - name: ${b_2033}
     address: 2033
     id: bypass_valve_on_off
-    #value_type: U_WORD
     min_value: 0
     max_value: 1
     step: 1
-    #initial_value: 0
-    register_type: holding
     platform: modbus_controller
     modbus_controller_id: ${modbus_id}
     use_write_multiple: true
     icon: mdi:toggle-switch-variant
-
 
 switch:
   - platform: template
@@ -64,7 +61,7 @@ switch:
                 id: fan_demand_value
                 value: 0 # Set the fan back to auto.
           else:
-            - logger.log: "The sensor value is below 200!, turn on bypass"
+            - logger.log: "The sensor value is already below 200 we can turn on bypass"
             - number.set:
                 id: bypass_valve_on_off
                 value: 1 # Set the bypass to on.
@@ -74,7 +71,7 @@ switch:
           condition:
             lambda: 'return id(hru_m3h_toevoer_binnen_total).state > 200;'
           then: 
-            - logger.log: "The sensor value is above 200, change fan to 200 before turn off"
+            - logger.log: "The sensor value is above 200, change fan to 200 before turning off"
             - number.set:
                 id: fan_demand_value
                 value: 200 # Lower the fan to the bypass allowed value

--- a/esphome/base/fan.yaml
+++ b/esphome/base/fan.yaml
@@ -1,21 +1,28 @@
 ###
 ##
-# Controlling fan
+# Controlling the WTW fan
+
+##
+# These are the numbers for the fan:
+# 2010: Demand ventilation: Going to the building - Intake
+# 2011: Demand ventilation: Turn on / off
+# 2012: Demand ventilation: Going to outfide - Exhaust
+# 2013: Demand ventilation: Turn on / off
+# 2020: Volume flow: intake fan
+# 2021: Volume flow: intake fan: Turn on / off
+# 2022: Volume flow: exhaust fan
+# 2023: Volume flow: exhaust fan: Turn on / off
+
 number:
-#######
-  # Demand ventialtion: (ingress)
-#######
   - name: ${f_2010} 
     platform: modbus_controller
     modbus_controller_id: ${modbus_id}
     id: fan_demand_value
     icon: mdi:home-import-outline
-    register_type: holding
     address: 2010
     min_value: 0
-    max_value: ${max_cap}
+    max_value: ${max.cap}
     step: 1
-    #initial_value: 0
     value_type: U_WORD
     use_write_multiple: true
     on_value_range:
@@ -33,66 +40,53 @@ number:
     platform: modbus_controller
     modbus_controller_id: ${modbus_id}
     id: fan_demand_on_off
-    register_type: holding
     address: 2011
     min_value: 0
     max_value: 1
     step: 1
     use_write_multiple: true
-    icon: mdi:toggle-switch-variant
-#######
-  # Demand ventialtion: (exhaust)
-#######  
-  - name: ${f_2012}
-    address: 2012
-    id: fan_exhaust_demand_value
-    unit_of_measurement: m3/h
-    #value_type: U_WORD
-    min_value: 0
-    max_value: ${max_cap}
-    step: 1
-    #initial_value: 0
-    register_type: holding
-    platform: modbus_controller
-    modbus_controller_id: ${modbus_id}
-    icon: mdi:home-export-outline
-    on_value_range:
-      - above: 2.0
-        then: 
-          - number.set:
-              id: fan_flow_exhaust_on_off
-              value: 1.0
-      - below: 1.0
-        then:
-          - number.set:
-              id: fan_flow_exhaust_on_off
-              value: 0.0
-  - name: ${f_2013}
-    id: fan_flow_exhaust_on_off
-    address: 2013
-    #value_type: U_WORD
-    min_value: 0
-    max_value: 1
-    step: 1
-    register_type: holding
-    platform: modbus_controller
-    modbus_controller_id: ${modbus_id}
-    use_write_multiple: true
-    icon: mdi:toggle-switch-variant
-#######
-  ## By Flow
-#######
+    icon: mdi:toggle-switch-variant 
+  # - name: ${f_2012}
+  #   address: 2012
+  #   id: fan_exhaust_demand_value
+  #   unit_of_measurement: m3/h
+  #   min_value: 0
+  #   max_value: ${max.cap}
+  #   step: 1
+  #   platform: modbus_controller
+  #   modbus_controller_id: ${modbus_id}
+  #   icon: mdi:home-export-outline
+  #   use_write_multiple: true
+  #   on_value_range:
+  #     - above: 2.0
+  #       then: 
+  #         - number.set:
+  #             id: fan_flow_exhaust_on_off
+  #             value: 1.0
+  #     - below: 1.0
+  #       then:
+  #         - number.set:
+  #             id: fan_flow_exhaust_on_off
+  #             value: 0.0
+  # - name: ${f_2013}
+  #   id: fan_flow_exhaust_on_off
+  #   address: 2013
+  #   min_value: 0
+  #   max_value: 1
+  #   step: 1
+  #   platform: modbus_controller
+  #   modbus_controller_id: ${modbus_id}
+  #   use_write_multiple: true
+  #   icon: mdi:toggle-switch-variant
   - name: ${f_2020}
     platform: modbus_controller
     modbus_controller_id: ${modbus_id}
     id: fan_flow_ingress_value
     icon: mdi:home-import-outline
-    register_type: holding
     address: 2020
     min_value: 0
-    max_value: ${max_cap}
+    max_value: ${max.cap}
     step: 1
-    #initial_value: 0
     value_type: U_WORD
     use_write_multiple: true
     on_value_range:
@@ -110,12 +104,10 @@ number:
     platform: modbus_controller
     modbus_controller_id: ${modbus_id}
     id: fan_flow_ingress_on_off
-    register_type: holding
     address: 2021
     min_value: 0
     max_value: 1
     step: 1
-    #initial_value: 0
     use_write_multiple: true
     icon: mdi:toggle-switch-variant
 
@@ -150,7 +142,7 @@ output:
                   - number.set: { id: fan_demand_on_off, value: 1.0 }
                   - number.set:
                       id: fan_demand_value
-                      value: ${fan_speed_1}
+                      value: ${fan.speed_1}
             - if:
                 condition:
                   lambda: return (id(wtw_fan).speed == 2);
@@ -159,7 +151,7 @@ output:
                   - number.set: { id: fan_demand_on_off, value: 1.0 }
                   - number.set:
                       id: fan_demand_value
-                      value: ${fan_speed_2}
+                      value: ${fan.speed_2}
             - if:
                 condition:
                   lambda: return (id(wtw_fan).speed == 3);
@@ -168,7 +160,7 @@ output:
                   - number.set: { id: fan_demand_on_off, value: 1.0 }
                   - number.set:
                       id: fan_demand_value
-                      value: ${fan_speed_3}
+                      value: ${fan.speed_3}
             - if:
                 condition:
                   lambda: return (id(wtw_fan).speed == 4);
@@ -177,7 +169,7 @@ output:
                   - number.set: { id: fan_demand_on_off, value: 1.0 }
                   - number.set:
                       id: fan_demand_value
-                      value: ${fan_speed_4}
+                      value: ${fan.speed_4}
             - if:
                 condition:
                   lambda: return (id(wtw_fan).speed == 5);
@@ -186,7 +178,7 @@ output:
                   - number.set: { id: fan_demand_on_off, value: 1.0 }
                   - number.set:
                       id: fan_demand_value
-                      value: ${fan_speed_5}
+                      value: ${fan.speed_5}
             - if:
                 condition:
                   lambda: return (id(wtw_fan).speed == 6);
@@ -195,7 +187,7 @@ output:
                   - number.set: { id: fan_demand_on_off, value: 1.0 }
                   - number.set:
                       id: fan_demand_value
-                      value: ${fan_speed_6}
+                      value: ${fan.speed_6}
             - if:
                 condition:
                   lambda: return (id(wtw_fan).speed == 7);
@@ -204,12 +196,10 @@ output:
                   - number.set: { id: fan_demand_on_off, value: 1.0 }
                   - number.set:
                       id: fan_demand_value
-                      value: ${fan_speed_7}
+                      value: ${fan.speed_7}
       - if:
           condition:
             lambda: return !(id(wtw_fan).state);
           then:
             - logger.log: "fan_output_value: Back to auto"
             - number.set: { id: fan_demand_on_off, value: 0.0 }
-
-

--- a/esphome/base/faultcodes.yaml
+++ b/esphome/base/faultcodes.yaml
@@ -1,5 +1,8 @@
+##
+# All the fault codes that the unit generates.
+# These are writable for reset.
+##
 sensor:
-  # These are writable for reset:
   - name: ${s_199}
     address: 199
     value_type: U_WORD
@@ -8,7 +11,7 @@ sensor:
     platform: modbus_controller
     modbus_controller_id: ${modbus_id}
     entity_category: diagnostic
-    skip_updates: ${skip_updates_errors}
+    skip_updates: ${skip_updates.errors}
     icon: ${alert_icon}
   - name: ${s_200}
     address: 200
@@ -17,7 +20,7 @@ sensor:
     state_class: measurement
     platform: modbus_controller
     modbus_controller_id: ${modbus_id}
-    skip_updates: ${skip_updates_errors}
+    skip_updates: ${skip_updates.errors}
     entity_category: diagnostic
     icon: ${alert_icon}
   - name: ${s_201}
@@ -27,7 +30,7 @@ sensor:
     state_class: measurement
     platform: modbus_controller
     modbus_controller_id: ${modbus_id}
-    skip_updates: ${skip_updates_errors}
+    skip_updates: ${skip_updates.errors}
     entity_category: diagnostic
     icon: ${alert_icon}
   - name: ${s_202}
@@ -37,7 +40,7 @@ sensor:
     state_class: measurement
     platform: modbus_controller
     modbus_controller_id: ${modbus_id}
-    skip_updates: ${skip_updates_errors}
+    skip_updates: ${skip_updates.errors}
     entity_category: diagnostic
     icon: ${alert_icon}
   - name: ${s_203}
@@ -47,7 +50,7 @@ sensor:
     state_class: measurement
     platform: modbus_controller
     modbus_controller_id: ${modbus_id}
-    skip_updates: ${skip_updates_errors}
+    skip_updates: ${skip_updates.errors}
     entity_category: diagnostic
     icon: ${alert_icon}
   - name: ${s_210}
@@ -57,7 +60,7 @@ sensor:
     state_class: measurement
     platform: modbus_controller
     modbus_controller_id: ${modbus_id}
-    skip_updates: ${skip_updates_errors}
+    skip_updates: ${skip_updates.errors}
     entity_category: diagnostic
     icon: ${alert_icon}
   - name: ${s_211}
@@ -67,7 +70,7 @@ sensor:
     state_class: measurement
     platform: modbus_controller
     modbus_controller_id: ${modbus_id}
-    skip_updates: ${skip_updates_errors}
+    skip_updates: ${skip_updates.errors}
     entity_category: diagnostic
     icon: ${alert_icon}
   - name: ${s_212}
@@ -77,7 +80,7 @@ sensor:
     state_class: measurement
     platform: modbus_controller
     modbus_controller_id: ${modbus_id}
-    skip_updates: ${skip_updates_errors}
+    skip_updates: ${skip_updates.errors}
     entity_category: diagnostic
     icon: ${alert_icon}
   - name: ${s_213}
@@ -87,7 +90,7 @@ sensor:
     state_class: measurement
     platform: modbus_controller
     modbus_controller_id: ${modbus_id}
-    skip_updates: ${skip_updates_errors}
+    skip_updates: ${skip_updates.errors}
     entity_category: diagnostic
     icon: ${alert_icon}
   - name: ${s_214}
@@ -97,7 +100,7 @@ sensor:
     state_class: measurement
     platform: modbus_controller
     modbus_controller_id: ${modbus_id}
-    skip_updates: ${skip_updates_errors}
+    skip_updates: ${skip_updates.errors}
     entity_category: diagnostic
     icon: ${alert_icon}
   - name: ${s_215}
@@ -107,7 +110,7 @@ sensor:
     state_class: measurement
     platform: modbus_controller
     modbus_controller_id: ${modbus_id}
-    skip_updates: ${skip_updates_errors}
+    skip_updates: ${skip_updates.errors}
     entity_category: diagnostic
     icon: ${alert_icon}
   - name: ${s_216}
@@ -117,7 +120,7 @@ sensor:
     state_class: measurement
     platform: modbus_controller
     modbus_controller_id: ${modbus_id}
-    skip_updates: ${skip_updates_errors}
+    skip_updates: ${skip_updates.errors}
     entity_category: diagnostic
     icon: ${alert_icon}
   - name: ${s_217}
@@ -127,7 +130,7 @@ sensor:
     state_class: measurement
     platform: modbus_controller
     modbus_controller_id: ${modbus_id}
-    skip_updates: ${skip_updates_errors}
+    skip_updates: ${skip_updates.errors}
     entity_category: diagnostic
     icon: ${alert_icon}
   - name: ${s_218}
@@ -137,7 +140,7 @@ sensor:
     state_class: measurement
     platform: modbus_controller
     modbus_controller_id: ${modbus_id}
-    skip_updates: ${skip_updates_errors}
+    skip_updates: ${skip_updates.errors}
     entity_category: diagnostic
     icon: ${alert_icon}
   - name: ${s_219}
@@ -147,7 +150,7 @@ sensor:
     state_class: measurement
     platform: modbus_controller
     modbus_controller_id: ${modbus_id}
-    skip_updates: ${skip_updates_errors}
+    skip_updates: ${skip_updates.errors}
     icon: ${alert_icon}
     entity_category: diagnostic
   - name: ${s_220}
@@ -157,7 +160,7 @@ sensor:
     state_class: measurement
     platform: modbus_controller
     modbus_controller_id: ${modbus_id}
-    skip_updates: ${skip_updates_errors}
+    skip_updates: ${skip_updates.errors}
     entity_category: diagnostic
     icon: ${alert_icon}
   - name: ${s_221}
@@ -167,7 +170,7 @@ sensor:
     state_class: measurement
     platform: modbus_controller
     modbus_controller_id: ${modbus_id}
-    skip_updates: ${skip_updates_errors}
+    skip_updates: ${skip_updates.errors}
     entity_category: diagnostic
     icon: ${alert_icon}
   - name: ${s_222}
@@ -177,7 +180,7 @@ sensor:
     state_class: measurement
     platform: modbus_controller
     modbus_controller_id: ${modbus_id}
-    skip_updates: ${skip_updates_errors}
+    skip_updates: ${skip_updates.errors}
     icon: ${alert_icon}
     entity_category: diagnostic
   - name: ${s_230}
@@ -187,7 +190,7 @@ sensor:
     state_class: measurement
     platform: modbus_controller
     modbus_controller_id: ${modbus_id}
-    skip_updates: ${skip_updates_errors}
+    skip_updates: ${skip_updates.errors}
     icon: ${alert_icon}
     entity_category: diagnostic
   - name: ${s_231}
@@ -197,7 +200,7 @@ sensor:
     state_class: measurement
     platform: modbus_controller
     modbus_controller_id: ${modbus_id}
-    skip_updates: ${skip_updates_errors}
+    skip_updates: ${skip_updates.errors}
     icon: ${alert_icon}
     entity_category: diagnostic
   - name: ${s_232}
@@ -207,7 +210,7 @@ sensor:
     state_class: measurement
     platform: modbus_controller
     modbus_controller_id: ${modbus_id}
-    skip_updates: ${skip_updates_errors}
+    skip_updates: ${skip_updates.errors}
     icon: ${alert_icon}
     entity_category: diagnostic
   - name: ${s_233}
@@ -217,7 +220,7 @@ sensor:
     state_class: measurement
     platform: modbus_controller
     modbus_controller_id: ${modbus_id}
-    skip_updates: ${skip_updates_errors}
+    skip_updates: ${skip_updates.errors}
     icon: ${alert_icon}
     entity_category: diagnostic
 
@@ -226,68 +229,63 @@ number:
     modbus_controller_id: ${modbus_id}
     name: "${s_200} - Reset"
     id: HRU_errors1
-    register_type: holding
     address: 200
     value_type: U_WORD
-    skip_updates: ${skip_updates_errors}
+    skip_updates: ${skip_updates.errors}
     use_write_multiple: true
     entity_category: diagnostic
     icon: mdi:air-filter
     min_value: 0
-    max_value: ${max_error_number}
+    max_value: ${max.error_number}
     step: 1
   - platform: modbus_controller
     modbus_controller_id: ${modbus_id}
     name: "${s_201} - Reset"
     id: HRU_errors2
-    register_type: holding
     address: 201
     value_type: U_WORD
     use_write_multiple: true
-    skip_updates: ${skip_updates_errors}
+    skip_updates: ${skip_updates.errors}
     entity_category: diagnostic
     icon: mdi:air-filter
     min_value: 0
-    max_value: ${max_error_number}
+    max_value: ${max.error_number}
     step: 1
   - platform: modbus_controller
     modbus_controller_id: ${modbus_id}
     name: "${s_202} - Reset"
     id: HRU_errors3_egressFlow
-    register_type: holding
     address: 202
     value_type: U_WORD
     use_write_multiple: true
-    skip_updates: ${skip_updates_errors}
+    skip_updates: ${skip_updates.errors}
     icon: ${alert_icon}
     entity_category: diagnostic
     min_value: 0
-    max_value: ${max_error_number}
+    max_value: ${max.error_number}
     step: 1
   - platform: modbus_controller
     modbus_controller_id: ${modbus_id}
     name: ${s_203} - Reset
     id: HRU_errors4_ingressFlow
-    register_type: holding
     address: 203
     value_type: U_WORD
     use_write_multiple: true
-    skip_updates: ${skip_updates_errors}
+    skip_updates: ${skip_updates.errors}
     icon: ${alert_icon}
     entity_category: diagnostic
     min_value: 0
-    max_value: ${max_error_number}
+    max_value: ${max.error_number}
     step: 1
   - platform: modbus_controller
     modbus_controller_id: ${modbus_id}
     name: "${s_222} - Reset"
-    register_type: holding
     address: 222
     value_type: U_WORD
     use_write_multiple: true
-    skip_updates: ${skip_updates_errors}
+    skip_updates: ${skip_updates.errors}
     icon: ${alert_icon}
     entity_category: diagnostic
     min_value: 0
-    max_value: ${max_error_number}
+    max_value: ${max.error_number}
     step: 1

--- a/esphome/base/frostvalve.yaml
+++ b/esphome/base/frostvalve.yaml
@@ -1,27 +1,24 @@
+##
+# Frost valve
+# If the ingress air is far below freezing point, the WTW unit will open this valve.
+# Also the supply fan will spin harder. See manual page 15.
+##
 number:
-  # Frost valve
-  - name: ${fv_2030}
-    address: 2030
-    min_value: 0
-    max_value: 510
-    step: 510
-    #initial_value: 0
-    #value_type: U_WORD
-    register_type: holding
-    platform: modbus_controller
-    modbus_controller_id: ${modbus_id}
-    use_write_multiple: true
-    icon: mdi:snowflake-alert
+  # - name: ${fv_2030}
+  #   address: 2030
+  #   min_value: 0
+  #   max_value: 510
+  #   step: 510
+  #   platform: modbus_controller
+  #   modbus_controller_id: ${modbus_id}
+  #   use_write_multiple: true
+  #   icon: mdi:snowflake-alert
   - name: ${fv_2031}
     address: 2031
     min_value: 0
     max_value: 1
     step: 1
-    #initial_value: 0
-    #value_type: U_WORD
-    register_type: holding
     platform: modbus_controller
     modbus_controller_id: ${modbus_id}
     use_write_multiple: true
     icon: mdi:toggle-switch-variant
- 

--- a/esphome/base/general.yaml
+++ b/esphome/base/general.yaml
@@ -321,7 +321,7 @@ sensor:
     register_type: holding
     platform: modbus_controller
     modbus_controller_id: ${modbus_id}
-    skip_updates: ${skip_updates}
+    skip_updates: ${skip_updates.base}
     icon: mdi:clock
     state_class: "total_increasing"
   - name: ${s_4001}
@@ -332,7 +332,7 @@ sensor:
     state_class: "total_increasing"
     platform: modbus_controller
     modbus_controller_id: ${modbus_id}
-    skip_updates: ${skip_updates}
+    skip_updates: ${skip_updates.base}
     icon: mdi:clock
   - name: ${s_4002}
     address: 4002
@@ -341,7 +341,7 @@ sensor:
     register_type: holding
     platform: modbus_controller
     modbus_controller_id: ${modbus_id}
-    skip_updates: ${skip_updates}
+    skip_updates: ${skip_updates.base}
     state_class: "total_increasing"
     icon: mdi:clock
   - name: ${s_4003}
@@ -351,7 +351,7 @@ sensor:
     register_type: holding
     platform: modbus_controller
     modbus_controller_id: ${modbus_id}
-    skip_updates: ${skip_updates}
+    skip_updates: ${skip_updates.base}
     state_class: "total_increasing"
     icon: mdi:clock
 
@@ -363,15 +363,15 @@ number:
     min_value: 0
     max_value: 25
     step: 1
-    register_type: holding
     platform: modbus_controller
     modbus_controller_id: ${modbus_id}
+    use_write_multiple: true
   - name: ${s_2001}
     address: 2001
     value_type: U_WORD
     min_value: 0
     max_value: 1
     step: 1
-    register_type: holding
     platform: modbus_controller
     modbus_controller_id: ${modbus_id}
+    use_write_multiple: true

--- a/esphome/base/select.yaml
+++ b/esphome/base/select.yaml
@@ -26,16 +26,21 @@ select:
     entity_category: config
     use_write_multiple: true
     icon: mdi:toggle-switch-variant
-  - name: ${sl_499}
-    platform: modbus_controller
-    modbus_controller_id: ${modbus_id}
-    id: restrart_device
-    address: 499
-    optionsmap:
-      Running: 0
-      Restart: 1
-    entity_category: config
-    use_write_multiple: true
-    icon: mdi:toggle-switch-variant
-    skip_updates: 10
-    value_type: U_WORD
+
+##
+# Rebooting the device does produce errors, so we will turn if off. 
+##
+
+  # - name: ${sl_499}
+  #   platform: modbus_controller
+  #   modbus_controller_id: ${modbus_id}
+  #   id: restrart_device
+  #   address: 499
+  #   optionsmap:
+  #     Running: 0
+  #     Restart: 1
+  #   entity_category: config
+  #   use_write_multiple: true
+  #   icon: mdi:toggle-switch-variant
+  #   skip_updates: 10
+  #   value_type: U_WORD

--- a/esphome/boards/board-esp32-atom-s3-lite.yaml
+++ b/esphome/boards/board-esp32-atom-s3-lite.yaml
@@ -2,20 +2,22 @@
 # ESP settings
 ###
 esp32:
-  board: esp32-s3-devkitc-1 
+  board:        esp32-s3-devkitc-1 
+  flash_size:   8MB
+## Atom S3 lite  
   framework:
-    type: arduino
-    version: latest
+    type:       esp-idf
+    version:    recommended
 ###
 # Uart Settings
 ###
 uart:
-  id: uart_modbus
-  tx_pin: 6
-  rx_pin: 5
-  baud_rate: 19200
-  data_bits: 8
-  stop_bits: 1
-  parity: EVEN
+  id:           uart_modbus
+  tx_pin:       6
+  rx_pin:       5
+  baud_rate:    19200
+  data_bits:    8
+  stop_bits:    1
+  parity:       EVEN
   debug:
-    direction: BOTH
+    direction:  BOTH

--- a/esphome/zones/zone_1.yaml
+++ b/esphome/zones/zone_1.yaml
@@ -20,7 +20,7 @@ number:
     register_type: holding
     platform: modbus_controller
     modbus_controller_id: ${modbus_id}
-  # Ventialtion level zone 1
+  # ventilation level zone 1
   - name: ${s_2200}
     address: 2200
     min_value: 0


### PR DESCRIPTION
```
INFO ESPHome 2025.7.3
INFO Reading configuration /config/wtw-rs485-gh.yaml...
INFO Updating https://github.com/william-sy/esphome-Itho-Daalderop-HRU400@issue_7
INFO Generating C++ source...
INFO Compiling app...
Processing wtw-rs485-gh (board: esp32-s3-devkitc-1; framework: arduino; platform: https://github.com/pioarduino/platform-espressif32/releases/download/53.03.13/platform-espressif32.zip)
--------------------------------------------------------------------------------
HARDWARE: ESP32S3 240MHz, 320KB RAM, 8MB Flash
 - framework-arduinoespressif32 @ 3.1.3 
 - framework-arduinoespressif32-libs @ 5.3.0+sha.489d7a2b3a 
 - tool-esptoolpy @ 4.8.6 
 - tool-mklittlefs @ 3.2.0 
 - tool-riscv32-esp-elf-gdb @ 14.2.0+20240403 
 - tool-xtensa-esp-elf-gdb @ 14.2.0+20240403 
 - toolchain-riscv32-esp @ 13.2.0+20240530 
 - toolchain-xtensa-esp-elf @ 13.2.0+20240530
Dependency Graph
|-- Networking @ 3.1.3
|-- AsyncTCP @ 3.4.5
|-- WiFi @ 3.1.3
|-- FS @ 3.1.3
|-- Update @ 3.1.3
|-- ESPAsyncWebServer @ 3.7.10
|-- ESP32 Async UDP @ 3.1.3
|-- DNSServer @ 3.1.3
|-- ESPmDNS @ 3.1.3
|-- noise-c @ 0.1.10
|-- ArduinoJson @ 7.4.2
Compiling .pioenvs/wtw-rs485-gh/src/main.cpp.o
Linking .pioenvs/wtw-rs485-gh/firmware.elf
RAM:   [=         ]  14.4% (used 47276 bytes from 327680 bytes)
Flash: [=======   ]  66.5% (used 1220884 bytes from 1835008 bytes)
Building .pioenvs/wtw-rs485-gh/firmware.bin
Creating esp32s3 image...
Successfully created esp32s3 image.
esp32_create_combined_bin([".pioenvs/wtw-rs485-gh/firmware.bin"], [".pioenvs/wtw-rs485-gh/firmware.elf"])
SHA digest in image updated
Wrote 0x13a280 bytes to file /config/.esphome/build/wtw-rs485-gh/.pioenvs/wtw-rs485-gh/firmware.factory.bin, ready to flash to offset 0x0
esp32_copy_ota_bin([".pioenvs/wtw-rs485-gh/firmware.bin"], [".pioenvs/wtw-rs485-gh/firmware.elf"])
========================= [SUCCESS] Took 20.42 seconds =========================
```